### PR TITLE
Simplify travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,6 @@ os:
 smalltalk:
   - Pharo-6.1
 
-# Unit tests run the normal pillar tests
-# Integration tests test that pillar itself can interact with generated files, pdf generation, etc.
-# System tests test that we can install and use pillar as a black box
-env:
-  matrix:
-  - JOB=test TYPE=System ARCHETYPE=book OUTPUT=pdf
-
 install:
   - git clone https://github.com/pillar-markup/pillar.git -b newpipeline
   - ./pillar/scripts/build.sh 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,11 @@ env:
 install:
   - git clone https://github.com/pillar-markup/pillar.git -b newpipeline
   - ./pillar/scripts/build.sh 
-  - if [[ ${TYPE} == "Integration" ]] || [[ ${TYPE} == "System" ]]; then . pillar/scripts/ci/ensure_latex.sh; fi
-  - if [[ ${TYPE} == "Integration" ]] || [[ ${TYPE} == "System" ]]; then pillar/scripts/ci/ensure_book_dependencies.sh; fi
-  - if [[ ${TYPE} == "Integration" ]]; then mkdir -p $SMALLTALK_CI_BUILD; fi
-  - if [[ ${TYPE} == "Integration" ]]; then cp -r archetypes $SMALLTALK_CI_BUILD; fi
+  - . pillar/scripts/ci/ensure_latex.sh
+  - ./pillar/scripts/ci/ensure_book_dependencies.sh
   
 script:
-#- if [[ ${TYPE} == "System" ]]; then "pillar/scripts/system-tests/testarchetype.sh" ${ARCHETYPE} ${OUTPUT}; fi
-  - "pillar/pillar build pdf"
+  - ./pillar/pillar build pdf
 
 deploy:
 - provider: bintray

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,22 @@ os:
 smalltalk:
   - Pharo-6.1
 
+# Unit tests run the normal pillar tests
+# Integration tests test that pillar itself can interact with generated files, pdf generation, etc.
+# System tests test that we can install and use pillar as a black box
+env:
+  matrix:
+  - JOB=test TYPE=System ARCHETYPE=book OUTPUT=pdf
+
 install:
-  - git clone https://github.com/pillar-markup/pillar.git -b newpipeline
-  - ./pillar/scripts/build.sh 
-  - . pillar/scripts/ci/ensure_latex.sh
-  - ./pillar/scripts/ci/ensure_book_dependencies.sh
+  # Pillar installation
+  - git clone https://github.com/pillar-markup/pillar.git -b newpipeline  # Clone pillar
+  - cd pillar && ./scripts/build.sh                                       # Run pillar build script. Pillar will be built in `pwd`/build!
+  - . pillar/scripts/ci/ensure_latex.sh                                   # Install latex
+  - ./pillar/scripts/ci/ensure_book_dependencies.sh                       # Install latex dependencies required by pillar
   
 script:
-  - ./pillar/pillar build pdf
+  - ./pillar/build/pillar build pdf
 
 deploy:
 - provider: bintray

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 install:
   # Pillar installation
   - git clone https://github.com/pillar-markup/pillar.git -b newpipeline  # Clone pillar
-  - cd pillar && ./scripts/build.sh                                       # Run pillar build script. Pillar will be built in `pwd`/build!
+  - cd pillar && ./scripts/build.sh && cd ..                              # Run pillar build script. Pillar will be built in `pwd`/build!
   - . pillar/scripts/ci/ensure_latex.sh                                   # Install latex
   - ./pillar/scripts/ci/ensure_book_dependencies.sh                       # Install latex dependencies required by pillar
   


### PR DESCRIPTION
- Simplifying the travis file to avoid bash IFs, the unnecessary matrix
- fixed some bash commands (build/build => ./build/build)
- pillar's `build.sh` does build pillar in the working directory, not in the repository directory