### PR TITLE
Removed first occurrence of minusBinding

### DIFF
--- a/Chapters/Scheme.pillar
+++ b/Chapters/Scheme.pillar
@@ -647,11 +647,6 @@ Phsyche >> isEqualBinding
 ]]]
 
 [[[
-Phsyche >> minusBinding
-	^ #- -> [ :e :v | e - v ]
-]]]
-
-[[[
 Phsyche >> smallerBinding
 	^ #< -> [ :e :v | e < v ]
 ]]]


### PR DESCRIPTION
I removed the first occurrence of #minusBinding since it made more sense to keep it in the section called "Adding subtraction and division".